### PR TITLE
enable .csv output for job array listing 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/umr-lops/unifiedwvalticolocs"
 homepage = "https://github.com/umr-lops/unifiedwvalticolocs"
 
 [tool.poetry]
-version = "2026.4.28.post1"
+version = "2026.4.28.post2"
 
 
 

--- a/tests/test_create_listing_jobarray.py
+++ b/tests/test_create_listing_jobarray.py
@@ -2,14 +2,13 @@ import argparse
 import logging
 import os
 from datetime import datetime
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 import pytest
 from dateutil import rrule
 
 # Import the function to test
 from unifiedwvalticolocs.create_listing_jobarray import (
-    DEFAULT_OUTD,
     DEFAULT_SIF,
     all_altis,
     argument_parser,
@@ -31,6 +30,8 @@ def mock_args():
         alt=all_altis,
         config=None,
         sar_units=["S1A", "S1B"],
+        outputpath_csv="/path/to/listing.csv",
+        output_type="csv",
     )
 
 
@@ -38,7 +39,19 @@ def mock_args():
 def test_argument_parser():
     with patch(
         "sys.argv",
-        ["script.py", "--infra", "ice", "--start", "20240101", "--stop", "20240102"],
+        [
+            "script.py",
+            "--infra",
+            "ice",
+            "--start",
+            "20240101",
+            "--stop",
+            "20240102",
+            "--outputpath-csv",
+            "/path/to/listing.csv",
+            "--output-type",
+            "csv",
+        ],
     ):
         args = argument_parser()
         assert args.infra == "ice"
@@ -47,27 +60,28 @@ def test_argument_parser():
 
 
 def test_create_listing_jobarray(mock_args, caplog):
-    # Capture INFO-level logs (pytest defaults to WARNING)
     caplog.set_level(logging.INFO)
 
     with patch("os.makedirs") as mock_makedirs:
-        with patch("builtins.open", mock_open()) as mock_file:
+        # Mock pandas DataFrame.to_csv to avoid real file I/O
+        with patch("pandas.DataFrame.to_csv") as mock_to_csv:
+            # Call the function
             listing, cpt = create_listing_jobarray(mock_args)
 
         # Assertions
-        mock_makedirs.assert_called_once_with(DEFAULT_OUTD["ice"], exist_ok=True)
-        mock_file.assert_called_once_with(
-            os.path.join(
-                DEFAULT_OUTD["ice"],
-                "listing_coloc_CMEMS_CCI_Alti_WV_S1_CCI_jobarray.txt",
-            ),
-            "w",
+        mock_makedirs.assert_called_once_with(
+            os.path.dirname(mock_args.outputpath_csv), exist_ok=True
         )
 
-        # Check log messages
-        # assert "listing ready" in caplog.text
+        # Verify to_csv was called with expected arguments
+        mock_to_csv.assert_called_once()
+        # Optional: check the path argument if needed
+        # assert mock_to_csv.call_args[0][0].endswith("listing.csv")
+        assert mock_to_csv.call_args[1].get("index") is False
+
+        # Check output
         assert len(listing) > 0
-        # assert "nb lines : 64" in caplog.text
+        # assert cpt == 2 * 16 * 2  # 2 SAR units * 16 altimeters * 2 days
 
 
 def test_date_handling():

--- a/unifiedwvalticolocs/create_listing_jobarray.py
+++ b/unifiedwvalticolocs/create_listing_jobarray.py
@@ -6,6 +6,7 @@ import getpass
 import logging
 import os
 
+import pandas as pd
 from dateutil import rrule
 
 username = getpass.getuser()
@@ -70,6 +71,11 @@ def argument_parser():
         help="path where to store output coloc (.nc) [optional, set based on infrastructure] ",
     )
     parser.add_argument(
+        "--outputpath-csv",
+        required=True,
+        help="path where the listing for job array will be created. ",
+    )
+    parser.add_argument(
         "--image",
         required=False,
         default=DEFAULT_SIF,
@@ -93,6 +99,12 @@ def argument_parser():
         nargs="+",
         default=["S1A", "S1B", "S1C", "S1D"],
         help="List of SAR units to process (e.g., --sar-units S1A S1B) [default is all S1 units]",
+    )
+    parser.add_argument(
+        "--output-type",
+        required=True,
+        choices=["csv", "txt"],
+        help="Output format for the listing file: 'csv' or 'txt' [required]",
     )
     args = parser.parse_args()
     return args
@@ -149,12 +161,14 @@ def create_listing_jobarray(args):
     logging.info("default output dir: %s", outputdir)
     logging.info("default config: %s", config_path)
     logging.info("SAR units chosen: %s", args.sar_units)
+    logging.info("output listing format: %s", args.output_type)
 
-    os.makedirs(default_outputdir, exist_ok=True)
-    listing = os.path.join(
-        default_outputdir,
-        "listing_coloc_CMEMS_CCI_Alti_WV_S1_CCI_jobarray.txt",
-    )
+    # listing = os.path.join(
+    #     default_outputdir,
+    #     "listing_coloc_CMEMS_CCI_Alti_WV_S1_CCI_jobarray.%s" % args.output_type,
+    # )
+    listing = args.outputpath_csv
+    os.makedirs(os.path.dirname(listing), exist_ok=True)
 
     if args.start:
         sta = datetime.datetime.strptime(args.start, "%Y%m%d")
@@ -166,29 +180,52 @@ def create_listing_jobarray(args):
     else:
         sto = datetime.datetime.today()
 
-    fid = open(listing, "w")
+    if args.output_type == "txt":
+        fid = open(listing, "w")
     cpt = 0
-
+    lines_4_csv = []
     for sarunit in args.sar_units:
         for satalti in alti_chosen:
             for dd in rrule.rrule(rrule.DAILY, dtstart=sta, until=sto):
-                cmd_line = (
-                    "--startdate %s --sat %s --alt %s --outputdir %s --image %s --config %s"
-                    % (
-                        dd.strftime("%Y%m%d"),
-                        sarunit,
-                        satalti,
-                        outputdir,
-                        args.image,
-                        config_path,
+                if args.output_type == "csv":
+                    lines_4_csv.append(
+                        (
+                            dd.strftime("%Y%m%d"),
+                            sarunit,
+                            satalti,
+                            outputdir,
+                            args.image,
+                            config_path,
+                        )
                     )
-                )
-                if args.overwrite:
-                    cmd_line += " --redo"
+                elif args.output_type == "txt":
+                    cmd_line = (
+                        "--startdate %s --sat %s --alt %s --outputdir %s --image %s --config %s"
+                        % (
+                            dd.strftime("%Y%m%d"),
+                            sarunit,
+                            satalti,
+                            outputdir,
+                            args.image,
+                            config_path,
+                        )
+                    )
+                    if args.overwrite:
+                        cmd_line += " --redo"
+                    fid.write(cmd_line + "\n")
+                else:
+                    raise ValueError("Invalid output type. Use 'csv' or 'txt'.")
 
-                fid.write(cmd_line + "\n")
                 cpt += 1
-    fid.close()
+    if args.output_type == "txt":
+        fid.close()
+    if args.output_type == "csv":
+
+        df = pd.DataFrame(
+            lines_4_csv,
+            columns=["startdate", "sat", "alt", "outputdir", "image", "config"],
+        )
+        df.to_csv(listing, index=False)
 
     logging.info("listing ready : %s nb lines : %s", listing, cpt)
     return listing, cpt


### PR DESCRIPTION
## Description

the slurm job array operator from P. Louvart needs a manifest .csv or .json in argument.
I modify the script create_listing_jobarray to take this constraint into account.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/umr-lops/unifiedwvalticolocs/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/umr-lops/unifiedwvalticolocs/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
